### PR TITLE
Changed "alternative" to "fair" in the <title> tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta name="viewport" content="width=device-width" charset="UTF-8">
-<title>Alternative Voting Systems</title>
+<title>Fair Voting Systems</title>
 <script src='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.js'></script>
 <link href='https://api.mapbox.com/mapbox.js/v2.4.0/mapbox.css' rel='stylesheet' />
 <script type="text/javascript" src="js/tabletop.js"></script>


### PR DESCRIPTION
So, first of all, congrats on seeing this published!  But I couldn’t help noticing one tiny detail: the <title> tag, which is what gets picked up as tab/bookmark text in browsers, still said “Alternative voting systems” when it’s clear that Sightline have settled on “Fair voting systems” as their choice of words.  This PR is just a quick fix for that.